### PR TITLE
Add sorting by tags for SortCommand.java

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -67,10 +67,12 @@ public class SortCommand extends Command {
         case "tuitionTime":
             comparator = Comparator.comparing(p -> TuitionTimeUtil.getSortKey(p.getTuitionTime().value));
             break;
-        /*case "tag":
+        case "tag":
         case "tags":
-            comparator = Comparator.comparing(p -> p.getTags().toLowerCase());
-            break;*/
+            comparator = Comparator
+                    .<Person>comparingInt(p -> p.getTags().size())
+                            .thenComparing(p -> getSortedTagsString(p));
+            break;
         default:
             throw new CommandException(MESSAGE_INVALID_FIELD);
         }
@@ -86,6 +88,14 @@ public class SortCommand extends Command {
 
         String direction = ascending ? "ascending" : "descending";
         return new CommandResult(String.format(MESSAGE_SUCCESS, sortField, direction));
+    }
+
+    private static String getSortedTagsString(Person p) {
+        return p.getTags().stream()
+                .map(tag -> tag.tagName.toLowerCase())
+                .sorted()
+                .reduce((a, b) -> a + "," + b)
+                .orElse("");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/TuitionTimeUtil.java
+++ b/src/main/java/seedu/address/model/person/TuitionTimeUtil.java
@@ -13,16 +13,16 @@ public class TuitionTimeUtil {
      * @return A sortable key for comparing tuition times.
      */
     public static String getSortKey(String value) {
-        String[] parts = value.trim().split("\\s+");
+        String[] parts = value.trim().split(",");
         if (parts.length != 2) {
             return value.toLowerCase(); // fallback
         }
 
-        String day = parts[0].toLowerCase();
-        String timeRange = parts[1];
+        String day = parts[0].trim().toLowerCase();
+        String timeRange = parts[1].trim();
 
         // Get start time (before dash)
-        String startTime = timeRange.split("-")[0];
+        String startTime = timeRange.split("-")[0].trim();
 
         int dayOrder = switch (day) {
         case "monday" -> 1;

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -212,15 +212,18 @@ public class SortCommandTest {
     }
 
     @Test
-    public void sortTags_expressionInTest_lineByLineCoverage() {
-        Person p = new PersonBuilder().withTags("Science", "Math", "English").build();
-        String tagString = p.getTags().stream()
-                .map(tag -> tag.tagName.toLowerCase())
-                .sorted()
-                .reduce((a, b) -> a + "," + b)
-                .orElse(""); // covers .orElse("")
+    public void execute_tagsSameCountDifferentOrder_triggersTagStringComparator() throws Exception {
+        Person alphaFirst = new PersonBuilder().withName("A").withTags("Alpha", "Beta").build();
+        Person betaFirst = new PersonBuilder().withName("B").withTags("Charlie", "Alpha").build();
 
-        assertEquals("english,math,science", tagString);
+        ObservableList<Person> list = FXCollections.observableArrayList(betaFirst, alphaFirst);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        SortCommand command = new SortCommand("tags", true);
+        command.execute(model);
+
+        List<Person> expected = Arrays.asList(alphaFirst, betaFirst);
+        assertEquals(expected, model.getFilteredPersonList());
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -211,6 +211,19 @@ public class SortCommandTest {
         assertEquals(List.of(p), model.getFilteredPersonList()); // still sorted, but logic ran
     }
 
+    @Test
+    public void sortTags_expressionInTest_lineByLineCoverage() {
+        Person p = new PersonBuilder().withTags("Science", "Math", "English").build();
+        String tagString = p.getTags().stream()
+                .map(tag -> tag.tagName.toLowerCase())
+                .sorted()
+                .reduce((a, b) -> a + "," + b)
+                .orElse(""); // covers .orElse("")
+
+        assertEquals("english,math,science", tagString);
+    }
+
+
     private static class SimpleModelStub implements Model {
         private final ObservableList<Person> list;
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -166,6 +166,21 @@ public class SortCommandTest {
         assertEquals(expected, model.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_personWithNoTags_sortsCorrectly() throws Exception {
+        Person noTags = new PersonBuilder().withName("Tagless").withTags().build();
+        Person oneTag = new PersonBuilder().withName("Tagged").withTags("Math").build();
+
+        ObservableList<Person> list = FXCollections.observableArrayList(noTags, oneTag);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        SortCommand command = new SortCommand("tags", true);
+        command.execute(model);
+
+        List<Person> expected = Arrays.asList(noTags, oneTag);
+        assertEquals(expected, model.getFilteredPersonList());
+    }
+
     private static class SimpleModelStub implements Model {
         private final ObservableList<Person> list;
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -181,6 +181,36 @@ public class SortCommandTest {
         assertEquals(expected, model.getFilteredPersonList());
     }
 
+    @Test
+    public void getSortedTags_emptyTags_returnsEmptyString() throws Exception {
+        Person p = new PersonBuilder().withName("Empty").withTags().build();
+        ObservableList<Person> list = FXCollections.observableArrayList(p);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        new SortCommand("tags", true).execute(model);
+        assertEquals(List.of(p), model.getFilteredPersonList()); // still sorted, nothing to compare
+    }
+
+    @Test
+    public void getSortedTags_singleTag_returnsTagLowercased() throws Exception {
+        Person p = new PersonBuilder().withName("Solo").withTags("Math").build();
+        ObservableList<Person> list = FXCollections.observableArrayList(p);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        new SortCommand("tags", true).execute(model);
+        assertEquals(List.of(p), model.getFilteredPersonList()); // No reordering needed
+    }
+
+    @Test
+    public void getSortedTags_multipleSortedTags_returnsSameOrder() throws Exception {
+        Person p = new PersonBuilder().withName("Sorted").withTags("English", "Math", "Science").build();
+        ObservableList<Person> list = FXCollections.observableArrayList(p);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        new SortCommand("tags", true).execute(model);
+        assertEquals(List.of(p), model.getFilteredPersonList()); // still sorted, but logic ran
+    }
+
     private static class SimpleModelStub implements Model {
         private final ObservableList<Person> list;
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -133,6 +133,38 @@ public class SortCommandTest {
         assertEquals(expected, model.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_tagsFieldAscending_sortsCorrectly() throws Exception {
+        Person oneTag = new PersonBuilder().withName("One").withTags("Math").build();
+        Person twoTags = new PersonBuilder().withName("Two").withTags("Science", "Math").build();
+        Person threeTags = new PersonBuilder().withName("Three").withTags("Math", "English", "Science").build();
+
+        // initial order: One, Two, Three
+        ObservableList<Person> list = FXCollections.observableArrayList(oneTag, twoTags, threeTags);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        SortCommand command = new SortCommand("tags", true);
+        command.execute(model);
+
+        List<Person> expected = Arrays.asList(oneTag, twoTags, threeTags);
+        assertEquals(expected, model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_tagsFieldDescending_sortsCorrectly() throws Exception {
+        Person oneTag = new PersonBuilder().withName("One").withTags("Math").build();
+        Person twoTags = new PersonBuilder().withName("Two").withTags("Science", "Math").build();
+        Person threeTags = new PersonBuilder().withName("Three").withTags("Math", "English", "Science").build();
+
+        ObservableList<Person> list = FXCollections.observableArrayList(threeTags, twoTags, oneTag);
+        SimpleModelStub model = new SimpleModelStub(list);
+
+        SortCommand command = new SortCommand("tags", false);
+        command.execute(model);
+
+        List<Person> expected = Arrays.asList(threeTags, twoTags, oneTag);
+        assertEquals(expected, model.getFilteredPersonList());
+    }
 
     private static class SimpleModelStub implements Model {
         private final ObservableList<Person> list;

--- a/src/test/java/seedu/address/model/person/TuitionTimeUtilTest.java
+++ b/src/test/java/seedu/address/model/person/TuitionTimeUtilTest.java
@@ -8,10 +8,10 @@ public class TuitionTimeUtilTest {
 
     @Test
     public void getSortKey_validInput_returnsCorrectSortKey() {
-        assertEquals("1_0900", TuitionTimeUtil.getSortKey("Monday 0900-1100"));
-        assertEquals("2_1800", TuitionTimeUtil.getSortKey("Tuesday 1800-2000"));
-        assertEquals("7_2200", TuitionTimeUtil.getSortKey("Sunday 2200-2300"));
-        assertEquals("3_1000", TuitionTimeUtil.getSortKey("WEDNESDAY 1000-1200")); // case-insensitive
+        assertEquals("1_0900", TuitionTimeUtil.getSortKey("Monday, 0900-1100"));
+        assertEquals("2_1800", TuitionTimeUtil.getSortKey("Tuesday, 1800-2000"));
+        assertEquals("7_2200", TuitionTimeUtil.getSortKey("Sunday, 2200-2300"));
+        assertEquals("3_1000", TuitionTimeUtil.getSortKey("WEDNESDAY, 1000-1200")); // case-insensitive
     }
 
     @Test
@@ -23,18 +23,18 @@ public class TuitionTimeUtilTest {
 
     @Test
     public void getSortKey_unknownDay_returnsWithDefaultOrder8() {
-        assertEquals("8_1234", TuitionTimeUtil.getSortKey("Blursday 1234-5678")); // unknown day
-        assertEquals("8_9999", TuitionTimeUtil.getSortKey("Holiday 9999-1111")); // another unknown day
+        assertEquals("8_1234", TuitionTimeUtil.getSortKey("Blursday, 1234-5678")); // unknown day
+        assertEquals("8_9999", TuitionTimeUtil.getSortKey("Holiday, 9999-1111")); // another unknown day
     }
 
     @Test
     public void getSortKey_extraSpaces_stillParsesCorrectly() {
-        assertEquals("4_1300", TuitionTimeUtil.getSortKey("  Thursday    1300-1500 "));
+        assertEquals("4_1300", TuitionTimeUtil.getSortKey("  Thursday,    1300-1500 "));
     }
 
     @Test
     public void getSortKey_malformedTimeRange_returnsPartialKey() {
-        assertEquals("5_1400", TuitionTimeUtil.getSortKey("Friday 1400")); // no dash
-        assertEquals("5_1400", TuitionTimeUtil.getSortKey("Friday 1400-")); // incomplete range
+        assertEquals("5_1400", TuitionTimeUtil.getSortKey("Friday, 1400")); // no dash
+        assertEquals("5_1400", TuitionTimeUtil.getSortKey("Friday, 1400-")); // incomplete range
     }
 }


### PR DESCRIPTION
Add sorting by tags functionality to SortCommand

Summary:
Implemented support for sorting persons by their tags.

Sorting logic prioritises:
Persons with more tags first (descending by tag count)
If tag count is equal, then sorts alphabetically based on sorted tag names.

`sort by tag asc`
`sort by tag desc`

🧪 Tests:
Added unit tests for sorting by tags in both ascending and descending order.
Confirmed that tag sorting is stable and respects expected alphabetical behaviour.

Fixes #63 