### PR TITLE
Make command parsing case-insensitive

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -44,7 +44,7 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)


### PR DESCRIPTION
This PR makes command word parsing case insensitive. Users can now enter commands like `Add,` `add,` or `ADD,` and the application will correctly interpret them.

Previously, command words were case-sensitive. Commands like Add or DELETE would not be recognized, causing confusion for users.

✅ Fix:
- Modified AddressBookParser to convert the extracted command word to lowercase before parsing.
- Ensures that all command words are matched in a case-insensitive manner.

Fixes #83 

