### PR TITLE
Correct sort by name desc logic for name field

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid! ";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -96,10 +96,6 @@ public class SortCommand extends Command {
 
         assert comparator != null : "Comparator should have been set for sortField: " + sortField;
 
-        if (!ascending) {
-            comparator = comparator.reversed();
-        }
-
         model.sortFilteredPersonList(comparator);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         logger.info("Sort completed successfully");

--- a/src/main/java/seedu/address/ui/CommandConfig.java
+++ b/src/main/java/seedu/address/ui/CommandConfig.java
@@ -52,8 +52,8 @@ public class CommandConfig {
                 ),
                 new CommandUsageInfo(
                         "sort - Sort all contacts according to a field entered by user (ascending by default)",
-                        "sort [FIELD] asc/desc",
-                        "sort name asc or sort phone desc"
+                        "sort by [FIELD] asc/desc",
+                        "sort by name asc or sort by phone desc"
                 ),
                 new CommandUsageInfo(
                         "help - list all commands with explanation",

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -64,7 +64,7 @@ public class SortCommandTest {
         SortCommand command = new SortCommand("name", false);
         command.execute(model);
 
-        List<Person> expected = Arrays.asList(alice, bob, charlie);
+        List<Person> expected = Arrays.asList(charlie, bob, alice);
         assertEquals(expected, model.getFilteredPersonList());
     }
 
@@ -162,7 +162,7 @@ public class SortCommandTest {
         SortCommand command = new SortCommand("tags", false);
         command.execute(model);
 
-        List<Person> expected = Arrays.asList(oneTag, twoTags, threeTags);
+        List<Person> expected = Arrays.asList(threeTags, twoTags, oneTag);
         assertEquals(expected, model.getFilteredPersonList());
     }
 


### PR DESCRIPTION
This PR fixes a bug where the sort by name desc command returns names in the wrong order when contacts have full names (e.g., "Brandon Koh", "David Chong").

When sorting by name in descending order, the SortCommand logic reverses the comparator twice. This effectively cancels the intended reverse order and results in the list being sorted as if in ascending order.

✅ Fix
- Removed the duplicate call to comparator.reversed() in SortCommand.java.
- Now, the comparator is reversed exactly once when ascending is false.

Fixes #85 
Fixes #87 
Fixes #88